### PR TITLE
Move `jobs.openweb.dev` to `jobs.nearspace.info`

### DIFF
--- a/imports/client/components/layout/layout.jade
+++ b/imports/client/components/layout/layout.jade
@@ -48,7 +48,7 @@ template(name="layout")
           li: a(href="https://explorer.near.org/" target="_blank" rel="noopener noreferrer" title="NEAR Protocol Explorer") Explorer
           li: a(href="https://near.dev/" target="_blank" rel="noopener noreferrer" title="NEAR Protocol Examples") Examples
           li: a(href="https://docs.near.org/" target="_blank" rel="noopener noreferrer" title="NEAR Protocol Documentation") Docs
-          li: a(href="https://jobs.openweb.dev/" target="_blank" rel="noopener noreferrer" title="NEAR Protocol Job Board") Jobs
+          li: a(href="https://jobs.nearspace.info/" target="_blank" rel="noopener noreferrer" title="NEAR Protocol Job Board") Jobs
       .col.colspan-4
         ul.list-unstyled.social-icons-list
           li: a(href="https://gov.near.org/" target="_blank" rel="noopener noreferrer" title="NEAR Protocol Forum")

--- a/imports/server/pre-rendering.js
+++ b/imports/server/pre-rendering.js
@@ -3,7 +3,7 @@ import { WebApp } from 'meteor/webapp';
 import Spiderable from 'meteor/ostrio:spiderable-middleware';
 
 WebApp.connectHandlers.use(new Spiderable({
-  rootURL: 'https://jobs.openweb.dev',
+  rootURL: 'https://jobs.nearspace.info',
   serviceURL: 'https://render.ostr.io',
   auth: Meteor.settings.prerenderKey
 }));

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,7 +3,7 @@
 server {
   listen 80;
   listen [::]:80;
-  server_name jobs.openweb.dev;
+  server_name jobs.nearspace.info;
 
   return 301 https://$host$request_uri;
 }
@@ -11,11 +11,11 @@ server {
 server {
   listen 443 ssl;
   listen [::]:443 ssl;
-  server_name jobs.openweb.dev;
+  server_name jobs.nearspace.info;
 
   # TLS CERTIFICATES
-  ssl_certificate /etc/letsencrypt/live/jobs.openweb.dev/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/jobs.openweb.dev/privkey.pem;
+  ssl_certificate /etc/letsencrypt/live/jobs.nearspace.info/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/jobs.nearspace.info/privkey.pem;
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,5 +5,5 @@ Disallow: /job/new
 Disallow: /job/*/edit
 Disallow: /profile/settings
 
-Sitemap: https://jobs.openweb.dev/sitemap.xml
-Host: https://jobs.openweb.dev
+Sitemap: https://jobs.nearspace.info/sitemap.xml
+Host: https://jobs.nearspace.info

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> 
   <url>
-    <loc>https://jobs.openweb.dev/</loc>
+    <loc>https://jobs.nearspace.info/</loc>
     <changefreq>monthly</changefreq>
   </url>
   <url>
-    <loc>https://jobs.openweb.dev/search/projects</loc>
+    <loc>https://jobs.nearspace.info/search/projects</loc>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>https://jobs.openweb.dev/search/candidates</loc>
+    <loc>https://jobs.nearspace.info/search/candidates</loc>
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>https://jobs.openweb.dev/search/jobs</loc>
+    <loc>https://jobs.nearspace.info/search/jobs</loc>
     <changefreq>daily</changefreq>
   </url>
 </urlset>


### PR DESCRIPTION
@zavodil I see that migration was done partially and links weren't updated everywhere in the template and other repos.

Sending this as PR for your review and partial merging if necessary